### PR TITLE
feat(plugin): ship a Claude Code plugin manifest alongside the Codex one

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,38 @@
+{
+  "name": "pireel-marketplace",
+  "owner": {
+    "name": "Pireel",
+    "url": "https://pireel.com"
+  },
+  "metadata": {
+    "description": "Pireel Studio plugin for Claude Code"
+  },
+  "plugins": [
+    {
+      "name": "pireel",
+      "source": "./plugins/pireel",
+      "description": "Edit multi-source videos and create finished cuts in Pireel Studio from Claude Code.",
+      "category": "design",
+      "homepage": "https://pireel.com",
+      "author": {
+        "name": "Pireel",
+        "url": "https://pireel.com"
+      },
+      "license": "Apache-2.0",
+      "keywords": [
+        "pireel",
+        "video",
+        "video-editing",
+        "talking-head",
+        "shorts",
+        "captions",
+        "subtitles",
+        "transcription",
+        "storyboard",
+        "motion-graphics",
+        "claude-code",
+        "mcp"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@ different versions for different platforms.
 
 ## Install as a Plugin
 
+The Plugin bundles the Pireel workflow and authenticated MCP connection. The same
+`plugins/pireel` bundle ships a Codex manifest and a Claude Code manifest, so both
+hosts install the identical workflow and `pireel` MCP server.
+
+### Codex
+
 In the Codex desktop app, open **Plugins**, install **Pireel Studio** when it is
-available in your plugin directory, then start a new chat. The Plugin bundles the
-Pireel workflow and authenticated MCP connection.
+available in your plugin directory, then start a new chat.
 
 For repository-marketplace testing in Codex CLI:
 
@@ -35,6 +40,22 @@ can coexist with a production `pireel` connection without silently routing work
 to the wrong environment. Start a new chat after installing or updating so the
 host loads the new Plugin and MCP configuration.
 
+### Claude Code
+
+Add this repository as a marketplace, install the Plugin, then start a new session
+so Claude Code loads the bundled Skill and MCP server:
+
+```bash
+claude plugin marketplace add pireel/pireel-agent
+claude plugin install pireel@pireel-marketplace
+```
+
+Run `/mcp` inside Claude Code to complete the OAuth sign-in for the `pireel`
+server. If you previously connected with `claude mcp add` or `npx skills add`,
+verify the Plugin connection first (`get_state` returns a snapshot), then remove
+the manual `pireel` MCP entry and the standalone Skill so only one copy stays
+active.
+
 Then tell your agent:
 
 > Set up Pireel and help me edit my first video.
@@ -52,9 +73,10 @@ npx skills add pireel/pireel-agent
 The standalone Skill uses the same workflow but registers the Pireel MCP server
 through the host's own MCP configuration.
 
-### Claude Code
+### Claude Code without Plugins
 
-You can also connect Claude Code directly:
+Prefer the Claude Code Plugin above. If Plugins are unavailable in your
+environment, you can still connect the MCP server directly:
 
 ```bash
 claude mcp add --transport http pireel https://pireel.com/api/studio/mcp
@@ -114,7 +136,8 @@ node scripts/release-channel.mjs production \
 ```
 
 The script refuses the wrong branch and Preview/stable SemVer mixups, then synchronizes the
-channel manifest, Plugin manifest, and bundled Skill baseline. CI runs the matching `--check`
+channel manifest, both Plugin manifests (`.codex-plugin/plugin.json` and
+`.claude-plugin/plugin.json`), and bundled Skill baseline. CI runs the matching `--check`
 command and separately verifies endpoint isolation.
 
 ## Usage and credits

--- a/plugins/pireel/.claude-plugin/plugin.json
+++ b/plugins/pireel/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "pireel",
+  "version": "0.7.2",
+  "description": "Edit multi-source videos and create finished cuts in Pireel Studio from your AI agent.",
+  "author": {
+    "name": "Pireel",
+    "url": "https://pireel.com"
+  },
+  "homepage": "https://pireel.com",
+  "repository": "https://github.com/pireel/pireel-agent",
+  "license": "Apache-2.0",
+  "keywords": [
+    "pireel",
+    "video",
+    "video-editing",
+    "talking-head",
+    "shorts",
+    "captions",
+    "subtitles",
+    "transcription",
+    "storyboard",
+    "motion-graphics",
+    "claude-code",
+    "mcp"
+  ],
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/"
+}

--- a/plugins/pireel/.mcp.json
+++ b/plugins/pireel/.mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "pireel": {
+      "type": "http",
       "url": "https://pireel.com/api/studio/mcp",
       "oauth_resource": "https://pireel.com/api/studio/mcp"
     }

--- a/scripts/release-channel.mjs
+++ b/scripts/release-channel.mjs
@@ -85,32 +85,49 @@ if (releaseBranch !== channel.branch) {
 
 const pluginRoot = join(root, channel.pluginRoot);
 const pluginPath = join(pluginRoot, '.codex-plugin/plugin.json');
+const claudePluginPath = join(pluginRoot, '.claude-plugin/plugin.json');
 const mcpPath = join(pluginRoot, '.mcp.json');
 const versionPath = join(pluginRoot, 'skills/pireel/VERSION');
 const marketplacePath = join(root, '.agents/plugins/marketplace.json');
+const claudeMarketplacePath = join(root, '.claude-plugin/marketplace.json');
 
 if (!checkOnly) {
-  const plugin = await readJson(pluginPath);
+  const [plugin, claudePlugin] = await Promise.all([readJson(pluginPath), readJson(claudePluginPath)]);
   plugin.version = channel.pluginVersion;
+  claudePlugin.version = channel.pluginVersion;
   await Promise.all([
     writeJson(channelsPath, channels),
     writeJson(pluginPath, plugin),
+    writeJson(claudePluginPath, claudePlugin),
     writeFile(versionPath, `${channel.workflowVersion}\n`),
   ]);
 }
 
-const [plugin, mcp, marketplace, installedWorkflowVersion] = await Promise.all([
+const [plugin, claudePlugin, mcp, marketplace, claudeMarketplace, installedWorkflowVersion] = await Promise.all([
   readJson(pluginPath),
+  readJson(claudePluginPath),
   readJson(mcpPath),
   readJson(marketplacePath),
+  readJson(claudeMarketplacePath),
   readFile(versionPath, 'utf8').then((value) => value.trim()),
 ]);
 const servers = Object.entries(mcp.mcpServers ?? {});
 
 if (plugin.name !== 'pireel') fail(`Plugin name must remain pireel, got ${plugin.name}`);
 if (plugin.version !== channel.pluginVersion) fail(`plugin.json has ${plugin.version}; channel declares ${channel.pluginVersion}`);
+if (claudePlugin.name !== 'pireel') fail(`Claude Code plugin name must remain pireel, got ${claudePlugin.name}`);
+if (claudePlugin.version !== channel.pluginVersion) {
+  fail(`.claude-plugin/plugin.json has ${claudePlugin.version}; channel declares ${channel.pluginVersion}`);
+}
 if (installedWorkflowVersion !== channel.workflowVersion) fail(`VERSION has ${installedWorkflowVersion}; channel declares ${channel.workflowVersion}`);
 if (marketplace.name !== channel.marketplace) fail(`Marketplace has ${marketplace.name}; channel declares ${channel.marketplace}`);
+if (claudeMarketplace.name !== channel.marketplace) {
+  fail(`Claude Code marketplace has ${claudeMarketplace.name}; channel declares ${channel.marketplace}`);
+}
+const claudeMarketplaceEntry = (claudeMarketplace.plugins ?? []).find((entry) => entry.name === 'pireel');
+if (claudeMarketplaceEntry?.source !== `./${channel.pluginRoot}`) {
+  fail(`Claude Code marketplace must list pireel with source ./${channel.pluginRoot}`);
+}
 if (servers.length !== 1 || servers[0][0] !== channel.mcpServer) {
   fail(`Expected exactly one MCP server named ${channel.mcpServer}`);
 }
@@ -118,8 +135,13 @@ for (const field of ['url', 'oauth_resource']) {
   const expected = `${channel.baseUrl}/api/studio/mcp`;
   if (servers[0][1]?.[field] !== expected) fail(`MCP ${field} must be ${expected}`);
 }
+// Claude Code requires an explicit transport; Codex tolerates the extra field.
+if (servers[0][1]?.type !== 'http') fail('MCP server type must be http');
 if (plugin.interface?.websiteURL !== channel.baseUrl) {
   fail(`Plugin websiteURL must be ${channel.baseUrl}`);
+}
+if (claudePlugin.homepage !== channel.baseUrl) {
+  fail(`Claude Code plugin homepage must be ${channel.baseUrl}`);
 }
 
 console.log(`${channelName}: plugin ${channel.pluginVersion}, workflow ${channel.workflowVersion} (${channel.mcpServer})`);


### PR DESCRIPTION
## Why

I followed `connect-agent.md` from Claude Code today. The guide (and `SKILL.md`) is emphatic that Plugin ranks above the standalone Skill, and it tells the agent to "install the Pireel Plugin through the host's native Plugin manager". But this repository only ships a Codex manifest (`.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json`), so Claude Code has no Plugin route: `claude plugin marketplace add pireel/pireel-agent` finds no `.claude-plugin/marketplace.json`, and the agent ends up at `npx skills add` + a manual `claude mcp add`, which the docs explicitly call the fallback.

Claude Code supports the same shape (a marketplace manifest at the repo root plus a plugin manifest next to `skills/` and `.mcp.json`), and other video-editor plugins already ship both manifests from one bundle. This PR does the same, without touching `plugins/pireel/skills/` so the workflow-baseline guard is unaffected.

## What changed

- **`.claude-plugin/marketplace.json`** at the repo root, named `pireel-marketplace` to match `release/channels.json`, listing `pireel` with `source: ./plugins/pireel`.
- **`plugins/pireel/.claude-plugin/plugin.json`** pointing at the existing `./skills/` and `./.mcp.json`, so Codex and Claude Code install the identical workflow and `pireel` MCP server. Version mirrors the Codex manifest (0.7.2).
- **`plugins/pireel/.mcp.json`** gains `"type": "http"`. Claude Code requires an explicit transport for remote servers; Codex tolerates the extra field (the ChatCut plugin ships the same combination for both hosts). `oauth_resource` is kept for Codex; Claude Code discovers OAuth from the `WWW-Authenticate` challenge.
- **`scripts/release-channel.mjs`** now writes the plugin version into both manifests and, on `--check`, also verifies the Claude Code marketplace name, the `pireel` entry's `source`, the plugin name/version/homepage, and the `http` transport. The existing `production-plugin-guard` and `skill-version-guard` workflows therefore cover the new files with no CI changes.
- **README**: a Claude Code subsection under "Install as a Plugin" (`claude plugin marketplace add pireel/pireel-agent` → `claude plugin install pireel@pireel-marketplace` → `/mcp` for OAuth), plus migration guidance for people who already have the manual MCP entry or standalone Skill. The old `claude mcp add` section is kept as the explicit no-Plugin fallback.

## Verification

- `claude plugin validate --strict .` and `claude plugin validate --strict plugins/pireel` both pass.
- Real install from this branch: `claude plugin marketplace add <path>` → `claude plugin install pireel@pireel-marketplace` → `claude plugin details` reports **Skills (1) pireel, MCP servers (1) pireel**. Uninstalled afterwards.
- `PIREEL_RELEASE_BRANCH=main node scripts/release-channel.mjs production --check` passes; a scratch run of `--plugin-version 0.7.3` updates `channels.json`, `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` in lockstep.
- The Preview-identity grep from `production-plugin-guard.yml` still returns nothing under `plugins/pireel`.

## Follow-ups I did not include (need a workflow-version bump or a preview-branch change)

1. `SKILL.md` detects a Plugin bundle by looking for `.codex-plugin/plugin.json` two directories up. With this PR, `.claude-plugin/plugin.json` sits at the same depth and should count too; otherwise a Claude Code Plugin install still thinks it is standalone and tries to migrate itself. That edit lives under `skills/`, so I left it for a release that bumps `VERSION`.
2. The `preview` branch needs the same two manifests with `pireel-preview` names if you want `claude plugin marketplace add pireel/pireel-agent#preview` to work.
3. `connect-agent.md` could list the two Claude Code commands next to the Codex ones under "Plugin — preferred".

---

中文简述：按 connect-agent.md 用 Claude Code 接入时，文档要求优先 Plugin，但仓库只有 Codex 清单，Claude Code 只能退到 Skill + 手动 MCP。这个 PR 复用同一个 `plugins/pireel` 目录补上 Claude Code 的 marketplace 和 plugin 清单，`.mcp.json` 加 `type: http`，发布脚本同步校验两份清单，README 补安装说明。本机真实安装验证通过；未动 `skills/` 目录以免触发版本守卫。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ReibGLFwPmtgDLc6wPpPF
