### PR TITLE
release: preview install commands and build checks (0.7.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ install the repository's `preview` branch as a separate marketplace:
 ```bash
 # Codex
 codex plugin marketplace add pireel/pireel-agent --ref preview
-codex plugin add pireel@pireel-preview
+codex plugin add pireel-preview@pireel-preview
 
 # Claude Code
 claude plugin marketplace add pireel/pireel-agent --ref preview
-claude plugin install pireel@pireel-preview
+claude plugin install pireel-preview@pireel-preview
 ```
 
 The Preview plugin registers the independent `pireel-preview` MCP server, so it

--- a/release/built-from.json
+++ b/release/built-from.json
@@ -2,6 +2,6 @@
   "channel": "preview",
   "version": "0.7.7",
   "source": "develop",
-  "sha": "c5babcebb0ddf506885da2af6bb1529202509984",
-  "builtAt": "2026-09-12T10:55:23.907Z"
+  "sha": "4cd8af35675f6be6657c4dde9a6d0bef426ea2f8",
+  "builtAt": "2026-09-12T18:05:46.417Z"
 }

--- a/scripts/build-channel.mjs
+++ b/scripts/build-channel.mjs
@@ -65,6 +65,18 @@ if (typeof version !== 'string' || !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
   fail(`package.json version must be plain SemVer X.Y.Z, got ${JSON.stringify(version)}`);
 }
 
+/* The README documents every channel's install commands literally, so the channel rewrite leaves it
+ * alone and the identity guard skips it. That makes a renamed plugin id silently wrong in the one
+ * string a user actually types: of `<id>@<marketplace>`, only the marketplace half is distinctive,
+ * so nothing else would notice. Check every channel, not just the one being built. */
+const readme = await readFile(join(root, 'README.md'), 'utf8');
+for (const [name, entry] of Object.entries(manifest.channels ?? {})) {
+  if (!entry?.marketplace || !entry.pluginName) continue;
+  const wrong = [...readme.matchAll(new RegExp(`([A-Za-z0-9_-]+)@${entry.marketplace}(?![\\w-])`, 'g'))]
+    .find((hit) => hit[1] !== entry.pluginName);
+  if (wrong) fail(`README.md installs ${wrong[0]}, but the ${name} channel publishes ${entry.pluginName}@${entry.marketplace}`);
+}
+
 /* The id the host registers this plugin under. Channels are installed side by side, so their ids
  * must differ: a host that keys plugin identity by name keeps one and drops the other, and the
  * session then talks to whichever environment survived. Production keeps the bare name so installs
@@ -227,6 +239,12 @@ const prose = await renderProse();
 
 if (checkOnly) {
   const problems = [];
+  // Match the write path's cleanup: a channel publishes exactly its two bundles.
+  // Checking expected files alone would silently accept an extra installable plugin.
+  for (const entry of await readdir(join(root, 'plugins'))) {
+    const path = `plugins/${entry}`;
+    if (path !== CODEX && path !== CLAUDE) problems.push(`unexpected: ${path}`);
+  }
   for (const [rel, want] of [...generated, ...prose]) {
     const have = await readFile(join(root, rel), 'utf8').catch(() => null);
     if (have === null) problems.push(`missing: ${rel}`);

--- a/scripts/build-channel.test.mjs
+++ b/scripts/build-channel.test.mjs
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { cp, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const source = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+function run(root, ...args) {
+  const result = spawnSync(process.execPath, ['scripts/build-channel.mjs', ...args], { cwd: root, encoding: 'utf8' });
+  if (result.error) throw result.error;
+  return { status: result.status, output: result.stdout + result.stderr };
+}
+
+for (const channel of ['production', 'preview']) {
+  test(`${channel}: check rejects leftover bundles and files without deleting them`, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pireel-build-channel-'));
+    try {
+      await cp(source, root, { recursive: true, filter: (path) => !/(?:^|[/\\])(?:\.git|node_modules)(?:[/\\]|$)/.test(path) });
+      let result = run(root, channel);
+      assert.equal(result.status, 0, result.output);
+      result = run(root, channel, '--check');
+      assert.equal(result.status, 0, result.output);
+      const name = channel === 'preview' ? 'pireel-preview' : 'pireel';
+      const extra = channel === 'preview' ? 'pireel' : 'pireel-preview';
+      await cp(join(root, 'plugins', name), join(root, 'plugins', extra), { recursive: true });
+      await writeFile(join(root, 'plugins', 'leftover.txt'), 'not a published bundle');
+      result = run(root, channel, '--check');
+      assert.notEqual(result.status, 0, result.output);
+      assert.match(result.output, new RegExp(`unexpected: plugins/${extra}`));
+      assert.match(result.output, /unexpected: plugins\/leftover\.txt/);
+      // A check is read-only: running it again must still report the unwanted content.
+      assert.notEqual(run(root, channel, '--check').status, 0);
+      result = run(root, channel);
+      assert.equal(result.status, 0, result.output);
+      result = run(root, channel, '--check');
+      assert.equal(result.status, 0, result.output);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
Built by `scripts/build-channel.mjs preview` from `develop` at `4cd8af35675f6be6657c4dde9a6d0bef426ea2f8`.

**The shipped bundle is unchanged**, so the version stays at 0.7.7. Nothing under `plugins/` moves; this publishes a corrected README and two build checks.

- **The preview install commands named the wrong plugin id.** Giving each channel its own id changed the one string a user types, and the README still said `pireel@pireel-preview` for both hosts. The correct commands are `pireel-preview@pireel-preview`. Someone following the README could add the marketplace and then fail to install from it.
- **The build now checks every channel's `<id>@<marketplace>` pair against the manifest**, on every build regardless of which channel is being built. The README documents all channels literally, so the channel rewrite leaves it alone and the identity guard skips it; only the marketplace half of that string is distinctive, which is why nothing caught this.
- **`--check` now rejects a bundle the build did not write.** It compared the files the build writes, which says nothing about a third bundle beside them. A leftover from a build under another id is fully installable. Covered by a test that plants one and asserts the check reports it without deleting anything.

The diff is exactly what publishes to the **preview** channel; merging is the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUWCTxGAriJgViGPZxTKVE